### PR TITLE
musleabihf cross compile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,11 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-        target: arm-unknown-linux-gnueabihf
+        target: arm-unknown-linux-musleabihf
     - name: Build
-      run: cd client && ./build.sh
+      run: cargo install cross && cd client && ./build.sh
     - name: Upload release archive
       uses: actions/upload-artifact@v4
       with:
         name: eInkVnc
-        path: client/target/arm-unknown-linux-gnueabihf/release/einkvnc*
+        path: client/target/arm-unknown-linux-musleabihf/release/einkvnc*

--- a/client/build.sh
+++ b/client/build.sh
@@ -60,4 +60,4 @@ skip) ;;
     ;;
 esac
 
-cargo build --release --target=arm-unknown-linux-gnueabihf
+cross build --release --target=arm-unknown-linux-musleabihf


### PR DESCRIPTION
fix GCLIB runtime problems

```
[root@kobo vncdev]# ./einkvnc --help
./einkvnc: /lib/libc.so.6: version `GLIBC_2.28' not found (required by ./einkvnc)
./einkvnc: /lib/libc.so.6: version `GLIBC_2.25' not found (required by ./einkvnc)
./einkvnc: /lib/libc.so.6: version `GLIBC_2.33' not found (required by ./einkvnc)
./einkvnc: /lib/libc.so.6: version `GLIBC_2.32' not found (required by ./einkvnc)
./einkvnc: /lib/libc.so.6: version `GLIBC_2.34' not found (required by ./einkvnc)
./einkvnc: /lib/libm.so.6: version `GLIBC_2.35' not found (required by ./einkvnc)
./einkvnc: /lib/libm.so.6: version `GLIBC_2.27' not found (required by ./einkvnc)
```