### PR TITLE
Color-INK > support Libra/Clara Colour models :rainbow: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ vncserver -localhost no -name home -xstartup $HOME/.vnc/anonymous-vnc_xstartup -
 ./run_emulator.sh localhost --port 5901 --password 123456 --contrast 2
 ```
 
+To simulate a color device https://github.com/ivy-rew/eink-vnc/pull/28, or one with another resolution, the `run_emulator.sh` must be edited. 
+Export the `product` environment variable, that matches your device.
+
 ## Derivatives
 
 This projects thrives due to great achievements of others... 

--- a/client/src/color.rs
+++ b/client/src/color.rs
@@ -1,39 +1,119 @@
 #![allow(unused)]
 
-pub const GRAY00: u8 = 0x00;
-pub const GRAY01: u8 = 0x11;
-pub const GRAY02: u8 = 0x22;
-pub const GRAY03: u8 = 0x33;
-pub const GRAY04: u8 = 0x44;
-pub const GRAY05: u8 = 0x55;
-pub const GRAY06: u8 = 0x66;
-pub const GRAY07: u8 = 0x77;
-pub const GRAY08: u8 = 0x88;
-pub const GRAY09: u8 = 0x99;
-pub const GRAY10: u8 = 0xAA;
-pub const GRAY11: u8 = 0xBB;
-pub const GRAY12: u8 = 0xCC;
-pub const GRAY13: u8 = 0xDD;
-pub const GRAY14: u8 = 0xEE;
-pub const GRAY15: u8 = 0xFF;
+use serde::{Serialize, Deserialize};
+use crate::geom::lerp;
 
-pub const BLACK: u8 = GRAY00;
-pub const WHITE: u8 = GRAY15;
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Color {
+    Gray(u8),
+    Rgb(u8, u8, u8),
+}
 
-pub const TEXT_NORMAL: [u8; 3] = [WHITE, BLACK, GRAY08];
-pub const TEXT_BUMP_SMALL: [u8; 3] = [GRAY14, BLACK, GRAY07];
-pub const TEXT_BUMP_LARGE: [u8; 3] = [GRAY11, BLACK, BLACK];
+impl Color {
+    pub fn gray(&self) -> u8 {
+        match *self {
+            Color::Gray(level) => level,
+            Color::Rgb(red, green, blue) => {
+                (red as f32 * 0.2126 + green as f32 * 0.7152 + blue as f32 * 0.0722) as u8
+            },
+        }
+    }
 
-pub const TEXT_INVERTED_SOFT: [u8; 3] = [GRAY05, WHITE, WHITE];
-pub const TEXT_INVERTED_HARD: [u8; 3] = [BLACK, WHITE, GRAY06];
+    pub fn rgb(&self) -> [u8; 3] {
+        match *self {
+            Color::Gray(level) => [level; 3],
+            Color::Rgb(red, green, blue) => [red, green, blue],
+        }
+    }
 
-pub const SEPARATOR_NORMAL: u8 = GRAY10;
-pub const SEPARATOR_STRONG: u8 = GRAY07;
+    pub fn from_rgb(rgb: &[u8]) -> Color {
+        Color::Rgb(rgb[0], rgb[1], rgb[2])
+    }
 
-pub const KEYBOARD_BG: u8 = GRAY12;
-pub const BATTERY_FILL: u8 = GRAY12;
-pub const READING_PROGRESS: u8 = GRAY07;
+    pub fn apply<F>(&self, f: F) -> Color where F: Fn(u8) -> u8 {
+        match *self {
+            Color::Gray(level) => Color::Gray(f(level)),
+            Color::Rgb(red, green, blue) => Color::Rgb(f(red), f(green), f(blue)),
+        }
+    }
 
-pub const PROGRESS_FULL: u8 = GRAY05;
-pub const PROGRESS_EMPTY: u8 = GRAY13;
-pub const PROGRESS_VALUE: u8 = GRAY06;
+    pub fn lerp(&self, color: Color, alpha: f32) -> Color {
+        match (*self, color) {
+            (Color::Gray(l1), Color::Gray(l2)) => Color::Gray(lerp(l1 as f32, l2 as f32, alpha) as u8),
+            (Color::Rgb(red, green, blue), Color::Gray(level)) => Color::Rgb(lerp(red as f32, level as f32, alpha) as u8,
+                                                                             lerp(green as f32, level as f32, alpha) as u8,
+                                                                             lerp(blue as f32, level as f32, alpha) as u8),
+            (Color::Gray(level), Color::Rgb(red, green, blue)) => Color::Rgb(lerp(level as f32, red as f32, alpha) as u8,
+                                                                             lerp(level as f32, green as f32, alpha) as u8,
+                                                                             lerp(level as f32, blue as f32, alpha) as u8),
+            (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => Color::Rgb(lerp(r1 as f32, r2 as f32, alpha) as u8,
+                                                                           lerp(g1 as f32, g2 as f32, alpha) as u8,
+                                                                           lerp(b1 as f32, b2 as f32, alpha) as u8),
+        }
+    }
+
+    pub fn invert(&mut self) {
+        match self {
+            Color::Gray(level) => *level = 255 - *level,
+            Color::Rgb(red, green, blue) => {
+                *red = 255 - *red;
+                *green = 255 - *green;
+                *blue = 255 - *blue;
+            },
+        }
+    }
+
+    pub fn shift(&mut self, drift: u8) {
+        match self {
+            Color::Gray(level) => *level = level.saturating_sub(drift),
+            Color::Rgb(red, green, blue) => {
+                *red = red.saturating_sub(drift);
+                *green = green.saturating_sub(drift);
+                *blue = blue.saturating_sub(drift);
+            },
+        }
+    }
+}
+
+macro_rules! gray {
+    ($a:expr) => ($crate::color::Color::Gray($a));
+}
+
+pub const GRAY00: Color = gray!(0x00);
+pub const GRAY01: Color = gray!(0x11);
+pub const GRAY02: Color = gray!(0x22);
+pub const GRAY03: Color = gray!(0x33);
+pub const GRAY04: Color = gray!(0x44);
+pub const GRAY05: Color = gray!(0x55);
+pub const GRAY06: Color = gray!(0x66);
+pub const GRAY07: Color = gray!(0x77);
+pub const GRAY08: Color = gray!(0x88);
+pub const GRAY09: Color = gray!(0x99);
+pub const GRAY10: Color = gray!(0xAA);
+pub const GRAY11: Color = gray!(0xBB);
+pub const GRAY12: Color = gray!(0xCC);
+pub const GRAY13: Color = gray!(0xDD);
+pub const GRAY14: Color = gray!(0xEE);
+pub const GRAY15: Color = gray!(0xFF);
+
+pub const BLACK: Color = GRAY00;
+pub const WHITE: Color = GRAY15;
+
+pub const TEXT_NORMAL: [Color; 3] = [WHITE, BLACK, GRAY08];
+pub const TEXT_BUMP_SMALL: [Color; 3] = [GRAY14, BLACK, GRAY07];
+pub const TEXT_BUMP_LARGE: [Color; 3] = [GRAY11, BLACK, BLACK];
+
+pub const TEXT_INVERTED_SOFT: [Color; 3] = [GRAY05, WHITE, WHITE];
+pub const TEXT_INVERTED_HARD: [Color; 3] = [BLACK, WHITE, GRAY06];
+
+pub const SEPARATOR_NORMAL: Color = GRAY10;
+pub const SEPARATOR_STRONG: Color = GRAY07;
+
+pub const KEYBOARD_BG: Color = GRAY12;
+pub const BATTERY_FILL: Color = GRAY12;
+pub const READING_PROGRESS: Color = GRAY07;
+
+pub const PROGRESS_FULL: Color = GRAY05;
+pub const PROGRESS_EMPTY: Color = GRAY13;
+pub const PROGRESS_VALUE: Color = GRAY06;

--- a/client/src/color.rs
+++ b/client/src/color.rs
@@ -97,6 +97,8 @@ pub const GRAY13: Color = gray!(0xDD);
 pub const GRAY14: Color = gray!(0xEE);
 pub const GRAY15: Color = gray!(0xFF);
 
+pub const RED: Color = Color::Rgb(255, 0, 0);
+
 pub const BLACK: Color = GRAY00;
 pub const WHITE: Color = GRAY15;
 

--- a/client/src/device.rs
+++ b/client/src/device.rs
@@ -5,6 +5,8 @@ use crate::input::TouchProto;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Model {
+    LibraColour,
+    ClaraColour,
     ClaraBW,
     Elipsa2E,
     Clara2E,
@@ -42,6 +44,8 @@ pub enum Orientation {
 impl fmt::Display for Model {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Model::LibraColour   => write!(f, "Libra Colour"),
+            Model::ClaraColour   => write!(f, "Clara Colour"),
             Model::ClaraBW       => write!(f, "Clara BW"),
             Model::Elipsa2E      => write!(f, "Elipsa 2E"),
             Model::Clara2E       => write!(f, "Clara 2E"),
@@ -210,6 +214,18 @@ impl Device {
                 dims: (1072, 1448),
                 dpi: 300,
             },
+            "spaColour" => Device {
+                model: Model::ClaraColour,
+                proto: TouchProto::MultiB,
+                dims: (1072, 1448),
+                dpi: 300,
+            },
+            "monza" => Device {
+                model: Model::LibraColour,
+                proto: TouchProto::MultiB,
+                dims: (1264, 1680),
+                dpi: 300,
+            },
             _ => Device {
                 model: if model_number == "320" { Model::TouchC } else { Model::TouchAB },
                 proto: TouchProto::Single,
@@ -219,12 +235,15 @@ impl Device {
         }
     }
 
+    pub fn color_samples(&self) -> usize {
+        match self.model {
+            Model::ClaraColour | Model::LibraColour => 3,
+            _ => 1,
+        }
+    }
+
     pub fn frontlight_kind(&self) -> FrontlightKind {
         match self.model {
-            Model::AuraONE |
-            Model::AuraONELimEd |
-            Model::AuraH2OEd2V1 |
-            Model::AuraH2OEd2V2 => FrontlightKind::Natural,
             Model::ClaraHD |
             Model::Forma |
             Model::Forma32GB |
@@ -233,7 +252,13 @@ impl Device {
             Model::Libra2 |
             Model::Clara2E |
             Model::Elipsa2E |
-            Model::ClaraBW => FrontlightKind::Premixed,
+            Model::ClaraBW |
+            Model::ClaraColour |
+            Model::LibraColour => FrontlightKind::Premixed,
+            Model::AuraONE |
+            Model::AuraONELimEd |
+            Model::AuraH2OEd2V1 |
+            Model::AuraH2OEd2V2 => FrontlightKind::Natural,
             _ => FrontlightKind::Standard,
         }
     }
@@ -249,14 +274,14 @@ impl Device {
 
     pub fn has_gyroscope(&self) -> bool {
         matches!(self.model,
-                 Model::Forma | Model::Forma32GB | Model::LibraH2O |
-                 Model::Elipsa | Model::Sage | Model::Libra2 | Model::Elipsa2E)
+                 Model::Forma | Model::Forma32GB | Model::LibraH2O | Model::Elipsa |
+                 Model::Sage | Model::Libra2 | Model::Elipsa2E | Model::LibraColour)
     }
 
     pub fn has_page_turn_buttons(&self) -> bool {
         matches!(self.model,
                  Model::Forma | Model::Forma32GB | Model::LibraH2O |
-                 Model::Sage | Model::Libra2)
+                 Model::Sage | Model::Libra2 | Model::LibraColour)
     }
 
     pub fn has_power_cover(&self) -> bool {
@@ -286,7 +311,9 @@ impl Device {
 
     pub fn mark(&self) -> u8 {
         match self.model {
-            Model::ClaraBW => 12,
+            Model::LibraColour => 13,
+            Model::ClaraBW |
+            Model::ClaraColour => 12,
             Model::Elipsa2E => 11,
             Model::Clara2E => 10,
             Model::Libra2 => 9,
@@ -355,7 +382,8 @@ impl Device {
             Model::LibraH2O => 0,
             Model::AuraH2OEd2V1 |
             Model::Forma | Model::Forma32GB |
-            Model::Sage | Model::Libra2 | Model::Elipsa2E => 1,
+            Model::Sage | Model::Libra2 | Model::Elipsa2E |
+            Model::LibraColour => 1,
             _ => 3,
         }
     }
@@ -390,7 +418,8 @@ impl Device {
             Model::LibraH2O => n ^ 1,
             Model::Libra2 |
             Model::Sage |
-            Model::Elipsa2E => (6 - n) % 4,
+            Model::Elipsa2E |
+            Model::LibraColour => (6 - n) % 4,
             Model::Elipsa => (4 - n) % 4,
             _ => n,
         }

--- a/client/src/framebuffer/image.rs
+++ b/client/src/framebuffer/image.rs
@@ -1,5 +1,5 @@
 use super::{Framebuffer, UpdateMode};
-use crate::color::{WHITE};
+use crate::color::{GRAY12, RED, WHITE};
 use crate::color::Color;
 use crate::geom::{lerp, Rectangle};
 use anyhow::{format_err, Context, Error};
@@ -230,6 +230,10 @@ impl<'a> ReadonlyPixmap<'a> {
         if self.samples == 1 {
             Color::Gray(self.data[addr])
         } else {
+            let max=self.data.len();
+            if (max < addr+4) {
+                return RED; // signal an invalid pixel request
+            }
             Color::from_rgb(&self.data[addr..addr+3])
         }
     }

--- a/client/src/framebuffer/image.rs
+++ b/client/src/framebuffer/image.rs
@@ -1,5 +1,6 @@
 use super::{Framebuffer, UpdateMode};
-use crate::color::WHITE;
+use crate::color::{WHITE};
+use crate::color::Color;
 use crate::geom::{lerp, Rectangle};
 use anyhow::{format_err, Context, Error};
 use std::fs::File;
@@ -9,35 +10,39 @@ use std::path::Path;
 pub struct Pixmap {
     pub width: u32,
     pub height: u32,
+    pub samples: usize,
     pub data: Vec<u8>,
 }
 
 impl Pixmap {
-    pub fn new(width: u32, height: u32) -> Pixmap {
-        let len = (width * height) as usize;
+    pub fn new(width: u32, height: u32, samples: usize) -> Pixmap {
+        let len = samples * (width * height) as usize;
         Pixmap {
             width,
             height,
-            data: vec![WHITE; len],
+            samples,
+            data: vec![WHITE.gray(); len],
         }
     }
 
-    pub fn try_new(width: u32, height: u32) -> Option<Pixmap> {
+    pub fn try_new(width: u32, height: u32, samples: usize) -> Option<Pixmap> {
         let mut data = Vec::new();
-        let len = (width * height) as usize;
+        let len = samples * (width * height) as usize;
         data.try_reserve_exact(len).ok()?;
-        data.resize(len, WHITE);
+        data.resize(len, WHITE.gray());
         Some(Pixmap {
             width,
             height,
+            samples,
             data,
         })
     }
 
-    pub fn empty(width: u32, height: u32) -> Pixmap {
+    pub fn empty(width: u32, height: u32, samples: usize) -> Pixmap {
         Pixmap {
             width,
             height,
+            samples,
             data: Vec::new(),
         }
     }
@@ -55,39 +60,43 @@ impl Pixmap {
         let decoder = png::Decoder::new(file);
         let mut reader = decoder.read_info()?;
         let info = reader.info();
-        let mut pixmap = Pixmap::new(info.width, info.height);
+        let mut pixmap = Pixmap::new(info.width, info.height, info.color_type.samples());
         reader.next_frame(pixmap.data_mut())?;
         Ok(pixmap)
     }
 
     #[inline]
-    pub fn get_pixel(&self, x: u32, y: u32) -> u8 {
+    pub fn get_pixel(&self, x: u32, y: u32) -> Color {
         if self.data.is_empty() {
             return WHITE;
         }
-        let addr = (y * self.width + x) as usize;
-        self.data[addr]
+        let addr = self.samples * (y * self.width + x) as usize;
+        if self.samples == 1 {
+            Color::Gray(self.data[addr])
+        } else {
+            Color::from_rgb(&self.data[addr..addr+3])
+        }
     }
 }
 
 impl Framebuffer for Pixmap {
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8) {
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color) {
         if x >= self.width || y >= self.height {
             return;
         }
         if self.data.is_empty() {
             return;
         }
-        let addr = (y * self.width + x) as usize;
-        self.data[addr] = color;
+        let addr = self.samples * (y * self.width + x) as usize;
+        if self.samples == 1 {
+            self.data[addr] = color.gray();
+        } else {
+            let rgb = color.rgb();
+            self.data[addr..addr+3].copy_from_slice(&rgb);
+        }
     }
 
-    fn get_pixel(&self, x: u32, y: u32) -> u8 {
-        let addr = (y * self.width + x) as usize;
-        return self.data[addr];
-    }
-
-    fn set_blended_pixel(&mut self, x: u32, y: u32, color: u8, alpha: f32) {
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32) {
         if alpha >= 1.0 {
             self.set_pixel(x, y, color);
             return;
@@ -98,9 +107,15 @@ impl Framebuffer for Pixmap {
         if self.data.is_empty() {
             return;
         }
-        let addr = (y * self.width + x) as usize;
-        let blended_color = lerp(self.data[addr] as f32, color as f32, alpha) as u8;
-        self.data[addr] = blended_color;
+        let addr = self.samples * (y * self.width + x) as usize;
+        if self.samples == 1 {
+            self.data[addr] = lerp(self.data[addr] as f32, color.gray() as f32, alpha) as u8;
+        } else {
+            let rgb = color.rgb();
+            for (i, c) in self.data[addr..addr+3].iter_mut().enumerate() {
+                *c = lerp(*c as f32, rgb[i] as f32, alpha) as u8;
+            }
+        }
     }
 
     fn invert_region(&mut self, rect: &Rectangle) {
@@ -109,9 +124,14 @@ impl Framebuffer for Pixmap {
         }
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
-                let addr = (y * self.width as i32 + x) as usize;
-                let color = 255 - self.data[addr];
-                self.data[addr] = color;
+                let addr = self.samples * (y * self.width as i32 + x) as usize;
+                if self.samples == 1 {
+                    self.data[addr] = 255 - self.data[addr];
+                } else {
+                    for c in self.data[addr..addr+3].iter_mut() {
+                        *c = 255 - *c;
+                    }
+                }
             }
         }
     }
@@ -122,9 +142,14 @@ impl Framebuffer for Pixmap {
         }
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
-                let addr = (y * self.width as i32 + x) as usize;
-                let color = self.data[addr].saturating_sub(drift);
-                self.data[addr] = color;
+                let addr = self.samples * (y * self.width as i32 + x) as usize;
+                if self.samples == 1 {
+                    self.data[addr] = self.data[addr].saturating_sub(drift);
+                } else {
+                    for c in self.data[addr..addr+3].iter_mut() {
+                        *c = c.saturating_sub(drift);
+                    }
+                }
             }
         }
     }
@@ -146,7 +171,7 @@ impl Framebuffer for Pixmap {
             File::create(path).with_context(|| format!("can't create output file {}", path))?;
         let mut encoder = png::Encoder::new(file, width, height);
         encoder.set_depth(png::BitDepth::Eight);
-        encoder.set_color(png::ColorType::Grayscale);
+        encoder.set_color(if self.samples == 3 { png::ColorType::Rgb } else { png::ColorType::Grayscale });
         let mut writer = encoder
             .write_header()
             .with_context(|| format!("can't write PNG header for {}", path))?;
@@ -191,16 +216,21 @@ impl Framebuffer for Pixmap {
 pub struct ReadonlyPixmap<'a> {
     pub width: u32,
     pub height: u32,
+    pub samples: usize,
     pub data: &'a Vec<u8>,
 }
 
 impl<'a> ReadonlyPixmap<'a> {
     #[inline]
-    pub fn get_pixel(&self, x: u32, y: u32) -> u8 {
+    pub fn get_pixel(&self, x: u32, y: u32) -> Color {
         if self.data.is_empty() {
             return WHITE;
         }
-        let addr = (y * self.width + x) as usize;
-        self.data[addr]
+        let addr = self.samples * (y * self.width + x) as usize;
+        if self.samples == 1 {
+            Color::Gray(self.data[addr])
+        } else {
+            Color::from_rgb(&self.data[addr..addr+3])
+        }
     }
 }

--- a/client/src/framebuffer/kobo1.rs
+++ b/client/src/framebuffer/kobo1.rs
@@ -6,6 +6,7 @@ use std::slice;
 use std::os::unix::io::AsRawFd;
 use std::ops::Drop;
 use anyhow::{Error, Context};
+use crate::color::Color;
 use crate::geom::Rectangle;
 use crate::device::{CURRENT_DEVICE, Model};
 use super::{UpdateMode, Framebuffer};
@@ -41,6 +42,9 @@ pub struct KoboFramebuffer1 {
     set_pixel_rgb: SetPixelRgb,
     get_pixel_rgb: GetPixelRgb,
     as_rgb: AsRgb,
+    red_index: usize,
+    green_index: usize,
+    blue_index: usize,
     bytes_per_pixel: u8,
     var_info: VarScreenInfo,
     fix_info: FixScreenInfo,
@@ -77,6 +81,7 @@ impl KoboFramebuffer1 {
             } else {
                 (set_pixel_rgb_8, get_pixel_rgb_8, as_rgb_8)
             };
+            let red_index = if var_info.red.offset > 0 { 2 } else { 0 };
             Ok(KoboFramebuffer1 {
                    file,
                    frame,
@@ -90,6 +95,9 @@ impl KoboFramebuffer1 {
                    set_pixel_rgb,
                    get_pixel_rgb,
                    as_rgb,
+                   red_index,
+                   green_index: 1,
+                   blue_index: 2 - red_index,
                    bytes_per_pixel: bytes_per_pixel as u8,
                    var_info,
                    fix_info,
@@ -103,34 +111,28 @@ impl KoboFramebuffer1 {
 }
 
 impl Framebuffer for KoboFramebuffer1 {
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8) {
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color) {
         let c = (self.transform)(x, y, color);
-        (self.set_pixel_rgb)(self, x, y, [c, c, c]);
+        (self.set_pixel_rgb)(self, x, y, c.rgb());
     }
 
-    fn get_pixel(&self, x: u32, y: u32) -> u8 {
-        let rgb = (self.get_pixel_rgb)(self, x, y);
-        return rgb[0];
-    }
-
-    fn set_blended_pixel(&mut self, x: u32, y: u32, color: u8, alpha: f32) {
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32) {
         if alpha >= 1.0 {
             self.set_pixel(x, y, color);
             return;
         }
-        let rgb = (self.get_pixel_rgb)(self, x, y);
-        let color_alpha = color as f32 * alpha;
-        let interp = (color_alpha + (1.0 - alpha) * rgb[0] as f32) as u8;
+        let background = Color::from_rgb(&(self.get_pixel_rgb)(self, x, y));
+        let interp = background.lerp(color, alpha);
         let c = (self.transform)(x, y, interp);
-        (self.set_pixel_rgb)(self, x, y, [c, c, c]);
+        (self.set_pixel_rgb)(self, x, y, c.rgb());
     }
 
     fn invert_region(&mut self, rect: &Rectangle) {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
                 let rgb = (self.get_pixel_rgb)(self, x as u32, y as u32);
-                let color = 255 - rgb[0];
-                (self.set_pixel_rgb)(self, x as u32, y as u32, [color, color, color]);
+                let color = [255 - rgb[0], 255 - rgb[1], 255 - rgb[2]];
+                (self.set_pixel_rgb)(self, x as u32, y as u32, color);
             }
         }
     }
@@ -139,8 +141,8 @@ impl Framebuffer for KoboFramebuffer1 {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
                 let rgb = (self.get_pixel_rgb)(self, x as u32, y as u32);
-                let color = rgb[0].saturating_sub(drift);
-                (self.set_pixel_rgb)(self, x as u32, y as u32, [color, color, color]);
+                let color = [rgb[0].saturating_sub(drift), rgb[1].saturating_sub(drift), rgb[2].saturating_sub(drift)];
+                (self.set_pixel_rgb)(self, x as u32, y as u32, color);
             }
         }
     }
@@ -154,6 +156,7 @@ impl Framebuffer for KoboFramebuffer1 {
 
         let update_marker = self.token;
         let mark = CURRENT_DEVICE.mark();
+        let color_samples = CURRENT_DEVICE.color_samples();
         let mut flags = self.flags;
         let mut monochrome = self.monochrome;
         let mut dithered = self.dithered;
@@ -161,7 +164,9 @@ impl Framebuffer for KoboFramebuffer1 {
         let (update_mode, mut waveform_mode) = match mode {
             UpdateMode::Gui => (UPDATE_MODE_PARTIAL, WAVEFORM_MODE_AUTO),
             UpdateMode::Partial => {
-                if mark >= 11 {
+                if mark >= 12 && color_samples > 1 && dithered {
+                    (UPDATE_MODE_FULL, HWTCON_WAVEFORM_MODE_GLRC16)
+                } else if mark >= 11 {
                     (UPDATE_MODE_PARTIAL, HWTCON_WAVEFORM_MODE_GLR16)
                 } else if mark >= 7 {
                     (UPDATE_MODE_PARTIAL, NTX_WFM_MODE_GLR16)
@@ -174,7 +179,11 @@ impl Framebuffer for KoboFramebuffer1 {
             },
             UpdateMode::Full => {
                 monochrome = false;
-                (UPDATE_MODE_FULL, NTX_WFM_MODE_GC16)
+                if mark >= 12 && color_samples > 1 && dithered {
+                    (UPDATE_MODE_FULL, HWTCON_WAVEFORM_MODE_GCC16)
+                } else {
+                    (UPDATE_MODE_FULL, NTX_WFM_MODE_GC16)
+                }
             },
             UpdateMode::Fast => {
                 if mark >= 11 {
@@ -212,7 +221,7 @@ impl Framebuffer for KoboFramebuffer1 {
 
         if self.inverted {
             if mark >= 11 {
-                if waveform_mode == HWTCON_WAVEFORM_MODE_GL16 {
+                if waveform_mode == HWTCON_WAVEFORM_MODE_GLR16 {
                     waveform_mode = HWTCON_WAVEFORM_MODE_GLKW16;
                 } else if waveform_mode == NTX_WFM_MODE_GC16 {
                     waveform_mode = HWTCON_WAVEFORM_MODE_GCK16;
@@ -471,10 +480,10 @@ fn set_pixel_rgb_32(fb: &mut KoboFramebuffer1, x: u32, y: u32, rgb: [u8; 3]) {
 
     unsafe {
         let spot = fb.frame.offset(addr) as *mut u8;
-        *spot.offset(0) = rgb[2];
-        *spot.offset(1) = rgb[1];
-        *spot.offset(2) = rgb[0];
-        // *spot.offset(3) = 0x00;
+        *spot.offset(0) = rgb[fb.red_index];
+        *spot.offset(1) = rgb[fb.green_index];
+        *spot.offset(2) = rgb[fb.blue_index];
+        // *spot.offset(3) = 0xFF;
     }
 }
 
@@ -503,7 +512,9 @@ fn get_pixel_rgb_32(fb: &KoboFramebuffer1, x: u32, y: u32) -> [u8; 3] {
                (fb.var_info.yoffset as isize + y as isize) * (fb.fix_info.line_length as isize);
     unsafe {
         let spot = fb.frame.offset(addr) as *mut u8;
-        [*spot.offset(2), *spot.offset(1), *spot.offset(0)]
+        [*spot.offset(fb.red_index as isize),
+         *spot.offset(fb.green_index as isize),
+         *spot.offset(fb.blue_index as isize)]
     }
 }
 
@@ -537,13 +548,13 @@ fn as_rgb_16(fb: &KoboFramebuffer1) -> Vec<u8> {
 fn as_rgb_32(fb: &KoboFramebuffer1) -> Vec<u8> {
     let (width, height) = fb.dims();
     let mut rgb888 = Vec::with_capacity((width * height * 3) as usize);
-    let bgra8888 = fb.as_bytes();
+    let data = fb.as_bytes();
     let virtual_width = fb.var_info.xres_virtual as usize;
-    for (_, bgra) in bgra8888.chunks(4).take(height as usize * virtual_width).enumerate()
-                           .filter(|&(i, _)| i % virtual_width < width as usize) {
-        let red = bgra[2];
-        let green = bgra[1];
-        let blue = bgra[0];
+    for (_, color) in data.chunks(4).take(height as usize * virtual_width).enumerate()
+                          .filter(|&(i, _)| i % virtual_width < width as usize) {
+        let red = color[fb.red_index];
+        let green = color[fb.green_index];
+        let blue = color[fb.blue_index];
         rgb888.extend_from_slice(&[red, green, blue]);
     }
     rgb888

--- a/client/src/framebuffer/kobo2.rs
+++ b/client/src/framebuffer/kobo2.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::ops::Drop;
 use anyhow::{Error, Context};
+use crate::color::Color;
 use crate::geom::Rectangle;
 use crate::device::CURRENT_DEVICE;
 use super::{UpdateMode, Framebuffer};
@@ -220,37 +221,36 @@ impl KoboFramebuffer2 {
         unsafe { slice::from_raw_parts(self.frame as *const u8, self.frame_size) }
     }
 
-}
-
-impl Framebuffer for KoboFramebuffer2 {
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8) {
-        let mut c = (self.transform)(x, y, color);
-        if self.inverted {
-            c = 255 - c;
-        }
-        let addr = (x + y * self.fix_info.line_length) as isize;
-        let spot = unsafe { self.frame.offset(addr) as *mut u8 };
-        unsafe { *spot = c };
-    }
-
-    fn get_pixel(&self, x: u32, y: u32) -> u8 {
+    fn get_pixel(&self, x: u32, y: u32) -> Color {
         let addr = (x + y * self.fix_info.line_length) as isize;
         let c = unsafe { *(self.frame.offset(addr) as *const u8) };
-        if self.inverted {
+        Color::Gray(if self.inverted {
             255 - c
         } else {
             c
-        }
+        })
     }
 
-    fn set_blended_pixel(&mut self, x: u32, y: u32, color: u8, alpha: f32) {
+}
+
+impl Framebuffer for KoboFramebuffer2 {
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color) {
+        let mut c = (self.transform)(x, y, color);
+        if self.inverted {
+            c.invert();
+        }
+        let addr = (x + y * self.fix_info.line_length) as isize;
+        let spot = unsafe { self.frame.offset(addr) as *mut u8 };
+        unsafe { *spot = c.gray() };
+    }
+
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32) {
         if alpha >= 1.0 {
             self.set_pixel(x, y, color);
             return;
         }
-        let cur = self.get_pixel(x, y);
-        let color_alpha = color as f32 * alpha;
-        let interp = (color_alpha + (1.0 - alpha) * cur as f32) as u8;
+        let background = self.get_pixel(x, y);
+        let interp = background.lerp(color, alpha);
         let c = (self.transform)(x, y, interp);
         self.set_pixel(x, y, c);
     }
@@ -258,8 +258,8 @@ impl Framebuffer for KoboFramebuffer2 {
     fn invert_region(&mut self, rect: &Rectangle) {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
-                let cur = self.get_pixel(x as u32, y as u32);
-                let color = 255 - cur;
+                let mut color = self.get_pixel(x as u32, y as u32);
+                color.invert();
                 self.set_pixel(x as u32, y as u32, color);
             }
         }
@@ -268,8 +268,8 @@ impl Framebuffer for KoboFramebuffer2 {
     fn shift_region(&mut self, rect: &Rectangle, drift: u8) {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
-                let cur = self.get_pixel(x as u32, y as u32);
-                let color = cur.saturating_sub(drift);
+                let mut color = self.get_pixel(x as u32, y as u32);
+                color.shift(drift);
                 self.set_pixel(x as u32, y as u32, color);
             }
         }

--- a/client/src/framebuffer/mod.rs
+++ b/client/src/framebuffer/mod.rs
@@ -11,7 +11,7 @@ use crate::pt;
 use crate::rect;
 use crate::vec2;
 
-use crate::color::{BLACK, WHITE};
+use crate::color::{Color, BLACK, WHITE};
 use crate::geom::{lerp, nearest_segment_point, surface_area, Point, Rectangle};
 use crate::geom::{BorderSpec, ColorSource, CornerSpec, Vec2};
 use anyhow::Error;
@@ -36,9 +36,8 @@ pub enum UpdateMode {
 }
 
 pub trait Framebuffer {
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8);
-    fn get_pixel(&self, x: u32, y: u32) -> u8;
-    fn set_blended_pixel(&mut self, x: u32, y: u32, color: u8, alpha: f32);
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color);
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32);
     fn invert_region(&mut self, rect: &Rectangle);
     fn shift_region(&mut self, rect: &Rectangle, drift: u8);
     fn update(&mut self, rect: &Rectangle, mode: UpdateMode) -> Result<u32, Error>;
@@ -79,12 +78,12 @@ pub trait Framebuffer {
         rect![0, 0, width as i32, height as i32]
     }
 
-    fn clear(&mut self, color: u8) {
+    fn clear(&mut self, color: Color) {
         let rect = self.rect();
         self.draw_rectangle(&rect, color);
     }
 
-    fn draw_rectangle(&mut self, rect: &Rectangle, color: u8) {
+    fn draw_rectangle(&mut self, rect: &Rectangle, color: Color) {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
                 self.set_pixel(x as u32, y as u32, color);
@@ -92,7 +91,7 @@ pub trait Framebuffer {
         }
     }
 
-    fn draw_blended_rectangle(&mut self, rect: &Rectangle, color: u8, alpha: f32) {
+    fn draw_blended_rectangle(&mut self, rect: &Rectangle, color: Color, alpha: f32) {
         for y in rect.min.y..rect.max.y {
             for x in rect.min.x..rect.max.x {
                 self.set_blended_pixel(x as u32, y as u32, color, alpha);
@@ -197,14 +196,17 @@ pub trait Framebuffer {
             for x in rect.min.x..rect.max.x {
                 let px = x - rect.min.x + pt.x;
                 let py = y - rect.min.y + pt.y;
-                let raw_color = pixmap.get_pixel(x as u32, y as u32) as f32;
-                let color = if raw_color < gray {
-                    (gray * (raw_color / gray).powf(exponent)) as u8
-                } else if raw_color > gray {
-                    (gray + rem_gray * ((raw_color - gray) / rem_gray).powf(inv_exponent)) as u8
-                } else {
-                    gray as u8
-                };
+                let raw_color = pixmap.get_pixel(x as u32, y as u32);
+                let color = raw_color.apply(|comp| {
+                    let c = comp as f32;
+                    if c < gray {
+                        (gray * (c / gray).powf(exponent)) as u8
+                    } else if c > gray {
+                        (gray + rem_gray * ((c - gray) / rem_gray).powf(inv_exponent)) as u8
+                    } else {
+                        gray as u8
+                    }
+                });
                 self.set_pixel(px as u32, py as u32, color);
             }
         }
@@ -228,18 +230,18 @@ pub trait Framebuffer {
         }
     }
 
-    fn draw_blended_pixmap(&mut self, pixmap: &Pixmap, pt: Point, color: u8) {
+    fn draw_blended_pixmap(&mut self, pixmap: &Pixmap, pt: Point, color: Color) {
         for y in 0..pixmap.height {
             for x in 0..pixmap.width {
                 let px = x + pt.x as u32;
                 let py = y + pt.y as u32;
-                let alpha = (255.0 - pixmap.get_pixel(x, y) as f32) / 255.0;
+                let alpha = (255.0 - pixmap.get_pixel(x, y).gray() as f32) / 255.0;
                 self.set_blended_pixel(px as u32, py as u32, color, alpha);
             }
         }
     }
 
-    fn draw_rounded_rectangle(&mut self, rect: &Rectangle, corners: &CornerSpec, color: u8) {
+    fn draw_rounded_rectangle(&mut self, rect: &Rectangle, corners: &CornerSpec, color: Color) {
         let (nw, ne, se, sw) = match *corners {
             CornerSpec::Uniform(v) => (v, v, v, v),
             CornerSpec::North(v) => (v, v, 0, 0),
@@ -334,7 +336,7 @@ pub trait Framebuffer {
                     if dist < mid_radius {
                         let delta_dist = small_radius as f32 - dist;
                         alpha = surface_area(delta_dist, angle);
-                        color = lerp(color as f32, border_color as f32, alpha) as u8;
+                        color = color.lerp(border_color, alpha);
                         alpha = 1.0;
                     } else {
                         let delta_dist = dist - radius as f32;
@@ -353,7 +355,7 @@ pub trait Framebuffer {
         }
     }
 
-    fn draw_triangle(&mut self, triangle: &[Point], color: u8) {
+    fn draw_triangle(&mut self, triangle: &[Point], color: Color) {
         let mut x_min = ::std::i32::MAX;
         let mut x_max = ::std::i32::MIN;
         let mut y_min = ::std::i32::MAX;
@@ -421,7 +423,7 @@ pub trait Framebuffer {
         }
     }
 
-    fn draw_disk(&mut self, center: Point, radius: i32, color: u8) {
+    fn draw_disk(&mut self, center: Point, radius: i32, color: Color) {
         let rect = Rectangle::from_disk(center, radius);
 
         for y in rect.min.y..rect.max.y {
@@ -435,14 +437,7 @@ pub trait Framebuffer {
         }
     }
 
-    fn draw_segment(
-        &mut self,
-        start: Point,
-        end: Point,
-        start_radius: f32,
-        end_radius: f32,
-        color: u8,
-    ) {
+    fn draw_segment(&mut self, start: Point, end: Point, start_radius: f32, end_radius: f32, color: Color) {
         let rect = Rectangle::from_segment(
             start,
             end,

--- a/client/src/framebuffer/mod.rs
+++ b/client/src/framebuffer/mod.rs
@@ -175,7 +175,7 @@ pub trait Framebuffer {
         } else {
             gray as u8
         };
-        self.set_pixel(x, y, color);
+        self.set_pixel(x, y, Color::Gray(color)); // dare to colorize?
     }
 
     fn draw_framed_pixmap_contrast(

--- a/client/src/framebuffer/mxcfb_sys.rs
+++ b/client/src/framebuffer/mxcfb_sys.rs
@@ -153,12 +153,15 @@ pub const EPDC_FLAG_USE_DITHERING_ORDERED: libc::c_int = 3;
 // pub const EPDC_FLAG_USE_DITHERING_QUANT_ONLY: libc::c_int = 4;
 
 /* Mark 11 */
-pub const HWTCON_WAVEFORM_MODE_GL16  :u32 = 3;
-pub const HWTCON_WAVEFORM_MODE_GLR16 :u32 = 4;
-pub const HWTCON_WAVEFORM_MODE_REAGL :u32 = 4;
-pub const HWTCON_WAVEFORM_MODE_A2    :u32 = 6;
-pub const HWTCON_WAVEFORM_MODE_GCK16 :u32 = 8;
-pub const HWTCON_WAVEFORM_MODE_GLKW16:u32 = 9;
+pub const HWTCON_WAVEFORM_MODE_GL16  :u32 =  3;
+pub const HWTCON_WAVEFORM_MODE_GLR16 :u32 =  4;
+pub const HWTCON_WAVEFORM_MODE_REAGL :u32 =  4;
+pub const HWTCON_WAVEFORM_MODE_A2    :u32 =  6;
+pub const HWTCON_WAVEFORM_MODE_GCK16 :u32 =  8;
+pub const HWTCON_WAVEFORM_MODE_GLKW16:u32 =  9;
+/* Mark 12 */
+pub const HWTCON_WAVEFORM_MODE_GCC16 :u32 = 10;
+pub const HWTCON_WAVEFORM_MODE_GLRC16:u32 = 11;
 
 pub const HWTCON_FLAG_USE_DITHERING: libc::c_uint = 0x1;
 pub const HWTCON_FLAG_FORCE_A2_OUTPUT: libc::c_uint = 16;

--- a/client/src/geom.rs
+++ b/client/src/geom.rs
@@ -3,6 +3,7 @@ use serde::{Serialize, Deserialize};
 use std::cmp::Ordering;
 use std::f32::consts;
 use std::ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign};
+use crate::color::Color;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Dir {
@@ -215,19 +216,19 @@ pub enum CornerSpec {
 }
 
 pub trait ColorSource {
-    fn color(&self, x: i32, y: i32) -> u8;
+    fn color(&self, x: i32, y: i32) -> Color;
 }
 
-impl<F> ColorSource for F where F: Fn(i32, i32) -> u8 {
+impl<F> ColorSource for F where F: Fn(i32, i32) -> Color {
     #[inline]
-    fn color(&self, x: i32, y: i32) -> u8 {
+    fn color(&self, x: i32, y: i32) -> Color {
         (self)(x, y)
     }
 }
 
-impl ColorSource for u8 {
+impl ColorSource for Color {
     #[inline]
-    fn color(&self, _: i32, _: i32) -> u8 {
+    fn color(&self, _: i32, _: i32) -> Color {
         *self
     }
 }
@@ -235,7 +236,7 @@ impl ColorSource for u8 {
 #[derive(Debug, Copy, Clone)]
 pub struct BorderSpec {
     pub thickness: u16,
-    pub color: u8,
+    pub color: Color,
 }
 
 const HALF_PIXEL_DIAGONAL: f32 = consts::SQRT_2 / 2.0;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -173,7 +173,7 @@ pub fn run(mut vnc: &mut Client, mut fb: &mut Box<dyn Framebuffer>, config: &Con
                         data: pixels,
                         samples: colors,
                     };
-                    debug!("Put pixels {} {} {} size {}",w,h,w*h,pixels.len());
+                    debug!("Put pixels w={} h={} w*h={} size={}",w,h,w*h,pixels.len());
 
                     let elapsed_ms = time_at_sol.elapsed().as_millis();
                     debug!("postproc Δt: {}", elapsed_ms);

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -152,10 +152,12 @@ pub fn run(mut vnc: &mut Client, mut fb: &mut Box<dyn Framebuffer>, config: &Con
                     let elapsed_ms = time_at_sol.elapsed().as_millis();
                     debug!("network Δt: {}", elapsed_ms);
 
+                    let steps = if CURRENT_DEVICE.color_samples() == 1 { 4 } else { 1 };
+                    let colors = if CURRENT_DEVICE.color_samples() == 1 { 1 } else { 4 };
                     let post_process = 
                         pixels
                             .iter()
-                            .step_by(4)
+                            .step_by(steps)
                             .map(|&c| post_proc_bin.data[c as usize])
                             .collect();
                     let pixels = &post_process;
@@ -169,6 +171,7 @@ pub fn run(mut vnc: &mut Client, mut fb: &mut Box<dyn Framebuffer>, config: &Con
                         width: w as u32,
                         height: h as u32,
                         data: pixels,
+                        samples: colors,
                     };
                     debug!("Put pixels {} {} {} size {}",w,h,w*h,pixels.len());
 
@@ -228,12 +231,12 @@ pub fn run(mut vnc: &mut Client, mut fb: &mut Box<dyn Framebuffer>, config: &Con
                         let dst_top = dst.top as u32;
 
                         let mut intermediary_pixmap =
-                            Pixmap::new(dst.width as u32, dst.height as u32);
+                            Pixmap::new(dst.width as u32, dst.height as u32, CURRENT_DEVICE.color_samples());
 
                         for y in 0..intermediary_pixmap.height {
                             for x in 0..intermediary_pixmap.width {
-                                let color = fb.get_pixel(src_left + x, src_top + y);
-                                intermediary_pixmap.set_pixel(x, y, color);
+                                //let color = fb.get_pixel(src_left + x, src_top + y);
+                                //intermediary_pixmap.set_pixel(x, y, color);
                             }
                         }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -5,11 +5,11 @@ extern crate log;
 extern crate byteorder;
 extern crate flate2;
 
+pub mod color;
 pub mod device;
 pub mod framebuffer;
 #[macro_use]
 pub mod geom;
-mod color;
 pub mod input;
 mod security;
 pub mod settings;

--- a/emulator/src/localbuffer.rs
+++ b/emulator/src/localbuffer.rs
@@ -5,6 +5,7 @@ use sdl2::pixels::{Color as SdlColor, PixelFormatEnum};
 use sdl2::render::{WindowCanvas, BlendMode};
 use einkvnc::framebuffer::{Framebuffer, UpdateMode};
 use einkvnc::geom::{Rectangle, Axis};
+use einkvnc::color::Color;
 use anyhow::{Context as ResultExt, Error};
 use chrono::Local;
 
@@ -117,10 +118,10 @@ impl Framebuffer for FBCanvas {
         Ok((width, height))
     }
 
-    fn get_pixel(&self, x: u32, y: u32) -> u8 {
-        debug!("virtualfb: get pixel {}/{}", x, y);
-        1
-    }
+    // fn get_pixel(&self, x: u32, y: u32) -> u8 {
+    //     debug!("virtualfb: get pixel {}/{}", x, y);
+    //     1
+    // }
 
     fn set_monochrome(&mut self, _enable: bool) {
         debug!("set mono {}", _enable)

--- a/emulator/src/localbuffer.rs
+++ b/emulator/src/localbuffer.rs
@@ -28,14 +28,15 @@ pub fn new(title: &str, width: u32, height: u32) -> Box<dyn Framebuffer>{
 pub struct FBCanvas(pub WindowCanvas);
 
 impl Framebuffer for FBCanvas {
-    fn set_pixel(&mut self, x: u32, y: u32, color: u8) {
-        self.0.set_draw_color(SdlColor::RGB(color, color, color));
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color) {
+        let [red, green, blue] = color.rgb();
+        self.0.set_draw_color(SdlColor::RGB(red, green, blue));
         self.0.draw_point(SdlPoint::new(x as i32, y as i32)).unwrap();
     }
-
-    fn set_blended_pixel(&mut self, x: u32, y: u32, color: u8, alpha: f32) {
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32) {
         debug!("set blended pixel {}/{}", x, y);
-        self.0.set_draw_color(SdlColor::RGBA(color, color, color, (alpha * 255.0) as u8));
+        let [red, green, blue] = color.rgb();
+        self.0.set_draw_color(SdlColor::RGBA(red, green, blue, (alpha * 255.0) as u8));
         self.0.draw_point(SdlPoint::new(x as i32, y as i32)).unwrap();
     }
 
@@ -49,7 +50,11 @@ impl Framebuffer for FBCanvas {
                 for x in rect.min.x..rect.max.x {
                     let u = (x - rect.min.x) as u32;
                     let addr = 3 * (v * width + u);
-                    let color = 255 - data[addr as usize];
+                    let red = data[addr as usize];
+                    let green = data[(addr+1) as usize];
+                    let blue = data[(addr+2) as usize];
+                    let mut color = Color::Rgb(red, green, blue);
+                    color.invert();
                     self.set_pixel(x as u32, y as u32, color);
                 }
             }
@@ -66,7 +71,11 @@ impl Framebuffer for FBCanvas {
                 for x in rect.min.x..rect.max.x {
                     let u = (x - rect.min.x) as u32;
                     let addr = 3 * (v * width + u);
-                    let color = data[addr as usize].saturating_sub(drift);
+                    let red = data[addr as usize];
+                    let green = data[(addr+1) as usize];
+                    let blue = data[(addr+2) as usize];
+                    let mut color = Color::Rgb(red, green, blue);
+                    color.shift(drift);
                     self.set_pixel(x as u32, y as u32, color);
                 }
             }

--- a/run_emulator.sh
+++ b/run_emulator.sh
@@ -5,9 +5,16 @@ deps(){
 	sudo apt install libevdev-dev
 }
 
-# simulate as Elipsa 2E
+# !simulate as Elipsa 2E
+# export MODEL_NUMBER=389
 export PRODUCT=condor
-export MODEL_NUMBER=389
+
+# !libra colour
+# export MODEL_NUMBER=390
+export PRODUCT=monza
+
+# !libra H20
+export PRODUCT=storm
 
 cd emulator
 cargo run "$@"


### PR DESCRIPTION
first primitive implementation of #27 

- disables contrast flags, on colour devices.
- colors are not yet natural ... red/blue/green swap ... but already looking promissing.

... we merge it as is; so we got Plato's latest device features onboard and can gradually adapt our own code.