### PR TITLE
fix: colours; transform from BGR to RGB

### DIFF
--- a/client/src/draw/pixmap.rs
+++ b/client/src/draw/pixmap.rs
@@ -27,7 +27,8 @@ impl<'a> ReadonlyPixmap<'a> {
             if max < addr+4 {
                 return RED; // signal an invalid pixel request
             }
-            Color::from_rgb(&self.data[addr..addr+3])
+            let bgr: &[u8] = &self.data[addr..addr+3];
+            Color::Rgb(bgr[2], bgr[1], bgr[0])
         }
     }
 }


### PR DESCRIPTION
fix the mixed up colors; on the e-reader (see blue :blue_heart:  and red :heart:  which are inverted)

before:
![before](https://github.com/user-attachments/assets/cab485bd-f376-4dca-83f7-ec482e3fa515)

after:
![after](https://github.com/user-attachments/assets/b07d2775-9239-4273-a35d-63a659c3d691)
